### PR TITLE
Fix particle camera culling.

### DIFF
--- a/main.js
+++ b/main.js
@@ -302,6 +302,7 @@ function initParticles(typeOfSimulation) {
     }
 
     particles = new THREE.Points( geometry, material );
+    particles.frustumCulled = false;
     particles.matrixAutoUpdate = false;
     particles.updateMatrix();
     scene.add( particles );


### PR DESCRIPTION
When the camera is positioned away from the center of the particles, They all disappear.
Disable camera frustum culling to fix this.

(Also this is my first pull request sorry if I got something wrong.)